### PR TITLE
chore: clarify that the SDK isn't officially supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hookdeck Ruby SDK
 
-The unofficial Ruby library for the [Hookdeck API](https://hookdeck.com).
+The unofficial Ruby library for the [Hookdeck API](https://hookdeck.com?ref=github-toluwaanimi-ruby-sdk).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hookdeck Ruby SDK
 
-The official Ruby library for the [Hookdeck API](https://hookdeck.com).
+The unofficial Ruby library for the [Hookdeck API](https://hookdeck.com).
 
 ## Installation
 


### PR DESCRIPTION
@toluwaanimi, thank you very much for the library. This is just a small change to avoid confusion over the level of support developers can expect from the library. While we'll do our best to help, ultimately, Hookdeck doesn't own and maintain the SDK.